### PR TITLE
Adding glob as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "tns-core-modules": "next"
   },
   "devDependencies": {
+    "glob": "^7.0.5",
     "nativescript-dev-typescript": "^0.3.2",
     "node-sass": "^3.8.0",
     "typescript": "^1.8.10"


### PR DESCRIPTION
Ping @NathanWalker.

Just an fyi that I needed to add “glob” as a devDependency to get this up and running.