### PR TITLE
Buttons base

### DIFF
--- a/app/pages/basics.xml
+++ b/app/pages/basics.xml
@@ -8,7 +8,8 @@
     </ActionBar>
   </Page.actionBar>
   <StackLayout>
-    <Label text="TODO :)" textWrap="true" />
-    
+      <Button text="Button" tap="" cssClass="btn-primary" />
+      <Button text="Button" tap="" cssClass="btn-outline-primary" />
+
   </StackLayout>
 </Page>

--- a/app/scss/_button.scss
+++ b/app/scss/_button.scss
@@ -1,4 +1,14 @@
-Button {
-  color: $btn-color;
-  @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-radius);
+
+.btn-primary {
+  color: $white;
+  background-color: $primary;
+  @include button-base($btn-padding-y, $btn-padding-x, $btn-margin-y, $btn-margin-x, $btn-font-size, $btn-radius);
+}
+
+.btn-outline-primary {
+  color: $primary;
+  background-color: transparent;
+  border-width: 1;
+  border-color: $primary;
+  @include button-base($btn-padding-y, $btn-padding-x, $btn-margin-y, $btn-margin-x, $btn-font-size, $btn-radius);
 }

--- a/app/scss/_button.scss
+++ b/app/scss/_button.scss
@@ -2,13 +2,11 @@
 .btn-primary {
   color: $white;
   background-color: $primary;
-  @include button-base($btn-padding-y, $btn-padding-x, $btn-margin-y, $btn-margin-x, $btn-font-size, $btn-radius);
+  @include button-base($primary, $btn-padding-y, $btn-padding-x, $btn-margin-y, $btn-margin-x, $btn-font-size, $btn-radius,1);
 }
 
 .btn-outline-primary {
   color: $primary;
   background-color: transparent;
-  border-width: 1;
-  border-color: $primary;
-  @include button-base($btn-padding-y, $btn-padding-x, $btn-margin-y, $btn-margin-x, $btn-font-size, $btn-radius);
+  @include button-base($primary, $btn-padding-y, $btn-padding-x, $btn-margin-y, $btn-margin-x, $btn-font-size, $btn-radius,1);
 }

--- a/app/scss/_variables.scss
+++ b/app/scss/_variables.scss
@@ -14,6 +14,9 @@ $btn-font-size: 18;
 $btn-radius: 0;
 $btn-padding-x: 10;
 $btn-padding-y: 10;
+$btn-margin-x:	16;
+$btn-margin-y:	8;
+
 
 // Options
 //

--- a/app/scss/mixins/_buttons.scss
+++ b/app/scss/mixins/_buttons.scss
@@ -1,6 +1,17 @@
 // Button sizes
+
+@mixin button-base($padding-y, $padding-x,$margin-y, $margin-x, $font-size, $border-radius){
+ @include button-size($padding-y, $padding-x, $font-size, $border-radius);
+  @include button-margin($margin-y,$margin-x);
+}
+
 @mixin button-size($padding-y, $padding-x, $font-size, $border-radius) {
   padding: $padding-y $padding-x $padding-y $padding-x;
   font-size: $font-size;
   @include border-radius($border-radius);
+}
+
+
+@mixin button-margin($margin-y, $margin-x) {
+  margin: $margin-y $margin-x $margin-y $margin-x;
 }

--- a/app/scss/mixins/_buttons.scss
+++ b/app/scss/mixins/_buttons.scss
@@ -1,7 +1,10 @@
 // Button sizes
 
-@mixin button-base($padding-y, $padding-x,$margin-y, $margin-x, $font-size, $border-radius){
- @include button-size($padding-y, $padding-x, $font-size, $border-radius);
+@mixin button-base($color, $padding-y, $padding-x,$margin-y, $margin-x, $font-size, $border-radius, $border-width){
+  border-width: $border-width;
+  border-color: $color;
+  text-transform: capitalize;
+  @include button-size($padding-y, $padding-x, $font-size, $border-radius);
   @include button-margin($margin-y,$margin-x);
 }
 
@@ -10,7 +13,6 @@
   font-size: $font-size;
   @include border-radius($border-radius);
 }
-
 
 @mixin button-margin($margin-y, $margin-x) {
   margin: $margin-y $margin-x $margin-y $margin-x;


### PR DESCRIPTION
Using mixin of btn-base wanted to see everyone’s thoughts about this. it looks good in IOS. 


Update: I end up fixing button size inconsistencies, by setting the button border width. however, we may still want to look into using platform specific css or https://www.npmjs.com/package/nativescript-platform-css.


Android:
<img width="480" alt="screen shot 2016-08-06 at 7 45 28 am" src="https://cloud.githubusercontent.com/assets/1486275/17456563/d0cb06b6-5ba9-11e6-9f46-bd0b13d2b371.png">


iOS:
<img width="377" alt="screen shot 2016-08-05 at 10 03 56 pm" src="https://cloud.githubusercontent.com/assets/1486275/17454090/98ab5e12-5b58-11e6-971c-94267c35104e.png">

