### PR TITLE
run instead emulate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Home of the core NativeScript theme, currently **under active development**.
 
 ## Setup
 
-Clone this repo, and then use the `tns emulate` or `tns run` command to launch the demo app on your device or emulator of choice.
+Clone this repo, and then use the `tns run` command to launch the demo app on your device or emulator of choice.
 
 ```
-tns emulate ios
+tns run ios
 
 // or
 


### PR DESCRIPTION
`run` will launch new emulator for both iOS and Android if no device or emulator available.