### PR TITLE
Switchs

### DIFF
--- a/app/pages/switches.xml
+++ b/app/pages/switches.xml
@@ -15,7 +15,6 @@
     </ActionBar>
   </Page.actionBar>
   <StackLayout>
-      <Switch />
-      
+      <Switch class="switch" />
   </StackLayout>
 </Page>

--- a/app/scss/_switch.scss
+++ b/app/scss/_switch.scss
@@ -1,3 +1,0 @@
-.switch {
-  color: $text-color;
-}

--- a/app/scss/themes/core/platforms/_index.android.scss
+++ b/app/scss/themes/core/platforms/_index.android.scss
@@ -4,3 +4,4 @@
 @import 'action-bar.android';
 @import 'buttons.android';
 @import 'labels.android';
+@import 'switches.android';

--- a/app/scss/themes/core/platforms/_index.ios.scss
+++ b/app/scss/themes/core/platforms/_index.ios.scss
@@ -3,3 +3,4 @@
  */
  @import 'buttons.ios';
  @import 'labels.ios';
+ @import 'switches.ios';

--- a/app/scss/themes/core/platforms/_switches.android.scss
+++ b/app/scss/themes/core/platforms/_switches.android.scss
@@ -1,0 +1,9 @@
+.switch{
+	margin:14 16;
+	color: $grey;
+	background-color: $grey;
+	&[checked=true]{
+		color: $accent;
+		background-color: $accent;
+	}
+}

--- a/app/scss/themes/core/platforms/_switches.ios.scss
+++ b/app/scss/themes/core/platforms/_switches.ios.scss
@@ -1,0 +1,7 @@
+.switch{
+	margin:8 15;
+	background-color: $accent;
+	&[checked=true]{
+		color:$grey;
+	}
+}


### PR DESCRIPTION
styling for switches is platform specific. not sure if we should keep
the main _switch file or not

![sample-android](https://cloud.githubusercontent.com/assets/1486275/17878396/6256c06e-68b8-11e6-9322-4a5909abe4ae.gif)


I'm not sure why android has such a light grey background, anyone have any suggestions?