### PR TITLE
Allow scss theme customizations

### DIFF
--- a/app/_custom.scss
+++ b/app/_custom.scss
@@ -1,0 +1,31 @@
+// Cusotmized Color Variables
+
+// Colors
+$black: #000 !default;
+$white: #fff !default;
+$base: $white !default;
+$grey: #e0e0e0 !default;
+$grey-background: #bababa !default;
+$charcoal:#303030 !default;
+$primary: lighten($black, 13%) !default;//rgba(0,0,0,.87);
+$secondary: lighten($black, 46%) !default;
+$disabled: lighten($black, 62%) !default;
+
+$accent: #09A52F !default;
+$error: #F74E2F !default;
+
+// Skin
+$background: #F0EED2 !default;
+$text-color: $primary !default;
+
+// Buttons
+$btn-color: $accent !default;
+$btn-color-secondary: #0FC572 !default;
+$btn-color-outline-highlighted: #0AC16E !default;
+$btn-color-disabled: #CCC4C9 !default;
+// $btn-font-size: 18 !default;
+// $btn-radius: 0 !default;
+// $btn-padding-x: 10 !default;
+// $btn-padding-y: 10 !default;
+// $btn-margin-x:	16 !default;
+// $btn-margin-y:	8 !default;

--- a/app/app.android.scss
+++ b/app/app.android.scss
@@ -4,7 +4,7 @@
  * Copyright 2016-2016 Telerik
  * Licensed under MIT (https://github.com/NativeScript/theme/blob/master/LICENSE)
  */
- 
+
 /**
  * Base style (un-themed)
  */

--- a/app/bootstrap-based.android.scss
+++ b/app/bootstrap-based.android.scss
@@ -1,16 +1,21 @@
-﻿/*!
+/*!
  * NativeScript Theme v0.1.0 (https://nativescript.org)
  * Copyright 2016-2016 The Theme Authors
  * Copyright 2016-2016 Telerik
  * Licensed under MIT (https://github.com/NativeScript/theme/blob/master/LICENSE)
  */
+ 
+// Variables form bootstrap v4 dependency
+@import 'bootstrap/scss/variables';
+// Import bootstrap-map patial to apply variable mapping
+@import 'scss/bootstrap-map';
 
 /**
  * Base style (un-themed)
  */
 @import 'scss/variables';
 @import 'scss/index';
-@import 'scss/themes/core/platforms/index.ios';
+@import 'scss/themes/core/platforms/index.android';
 
 // demo app
 @import 'demo';

--- a/app/bootstrap-based.ios.scss
+++ b/app/bootstrap-based.ios.scss
@@ -1,9 +1,14 @@
-﻿/*!
+/*!
  * NativeScript Theme v0.1.0 (https://nativescript.org)
  * Copyright 2016-2016 The Theme Authors
  * Copyright 2016-2016 Telerik
  * Licensed under MIT (https://github.com/NativeScript/theme/blob/master/LICENSE)
  */
+ 
+// Variables form bootstrap v4 dependency
+@import 'bootstrap/scss/variables';
+// Import bootstrap-map patial to apply variable mapping
+@import 'scss/bootstrap-map';
 
 /**
  * Base style (un-themed)

--- a/app/customized.android.scss
+++ b/app/customized.android.scss
@@ -1,16 +1,19 @@
-﻿/*!
+/*!
  * NativeScript Theme v0.1.0 (https://nativescript.org)
  * Copyright 2016-2016 The Theme Authors
  * Copyright 2016-2016 Telerik
  * Licensed under MIT (https://github.com/NativeScript/theme/blob/master/LICENSE)
  */
+ 
+// Theme variables cusomizations
+@import 'custom';
 
 /**
  * Base style (un-themed)
  */
 @import 'scss/variables';
 @import 'scss/index';
-@import 'scss/themes/core/platforms/index.ios';
+@import 'scss/themes/core/platforms/index.android';
 
 // demo app
 @import 'demo';

--- a/app/customized.ios.scss
+++ b/app/customized.ios.scss
@@ -1,9 +1,12 @@
-﻿/*!
+/*!
  * NativeScript Theme v0.1.0 (https://nativescript.org)
  * Copyright 2016-2016 The Theme Authors
  * Copyright 2016-2016 Telerik
  * Licensed under MIT (https://github.com/NativeScript/theme/blob/master/LICENSE)
  */
+ 
+// Theme variables cusomizations
+@import 'custom';
 
 /**
  * Base style (un-themed)

--- a/app/pages/themes.ts
+++ b/app/pages/themes.ts
@@ -9,7 +9,7 @@ export class ThemesModel extends BaseModel {
   public labelText: string;
   private _toggled: boolean = false;
 
-  constructor(page:Page) {
+  constructor(page: Page) {
     super(page);
     this.set('labelText', 'Default');
   }
@@ -29,6 +29,16 @@ export class ThemesModel extends BaseModel {
     themes.applyTheme(this.getPath('core.dark'));
   }
 
+  public applyCustom() {
+    this.set('labelText', 'Custom');
+    themes.applyTheme(this.getPath('customized'));
+  }
+
+  public applyBootstrap() {
+    this.set('labelText', 'Bootstrap');
+    themes.applyTheme(this.getPath('bootstrap-based'));
+  }
+
   private getPath(name: string) {
     let appPath = knownFolders.currentApp().path + '/';
     let platform = '';
@@ -37,6 +47,6 @@ export class ThemesModel extends BaseModel {
 }
 
 export function navigatingTo(args: EventData) {
-    var page = <Page>args.object;
-    page.bindingContext = new ThemesModel(page);
+  var page = <Page>args.object;
+  page.bindingContext = new ThemesModel(page);
 }

--- a/app/pages/themes.xml
+++ b/app/pages/themes.xml
@@ -13,6 +13,8 @@
         <Button text="Apply Default" tap="{{ applyDefault }}" class="btn" />
         <Button text="Apply Light" tap="{{ applyLight }}" class="btn" />
         <Button text="Apply Dark" tap="{{ applyDark }}" class="btn" />
+        <Button text="Apply Custom" tap="{{ applyCustom }}" class="btn" />
+        <Button text="Apply Bootstrap" tap="{{ applyBootstrap }}" class="btn" />
       </StackLayout>
     </drawer:RadSideDrawer.mainContent>
     <drawer:RadSideDrawer.drawerContent>

--- a/app/scss/_bootstrap-map.scss
+++ b/app/scss/_bootstrap-map.scss
@@ -1,0 +1,33 @@
+// Map NS theme variables to variables form the boothstrap v4 theme
+
+// Colors
+$black: #000 !default;
+$white: #fff !default;
+$base: $white !default;
+$grey: #e0e0e0 !default;
+$grey-background: #bababa !default;
+$charcoal:#303030 !default;
+
+$primary: lighten($black, 13%) !default;//rgba(0,0,0,.87);
+$secondary: lighten($black, 46%) !default;
+$disabled: $text-muted !default;
+
+$accent: $brand-primary !default;
+$error: $brand-danger !default;
+
+// Skin
+$background: $base !default;
+$text-color: $primary !default;
+
+// Buttons
+$btn-color: $btn-primary-bg !default;
+$btn-color-secondary: lighten($btn-primary-bg, 20%) !default;
+$btn-color-outline-highlighted: lighten($btn-color-secondary, 20%) !default;
+$btn-color-disabled: $btn-link-disabled-color !default;
+
+// $btn-font-size: 18 !default;
+// $btn-radius: 0 !default;
+// $btn-padding-x: 10 !default;
+// $btn-padding-y: 10 !default;
+// $btn-margin-x:	16 !default;
+// $btn-margin-y:	8 !default;

--- a/app/scss/_variables.scss
+++ b/app/scss/_variables.scss
@@ -1,31 +1,31 @@
 // Colors
-$black: #000;
-$white: #fff;
-$base: $white;
-$grey: #e0e0e0;
-$grey-background: #bababa;
-$charcoal:#303030;
-$primary: lighten($black, 13%);//rgba(0,0,0,.87);
-$secondary: lighten($black, 46%);
-$disabled: lighten($black, 62%);
-$accent: #30bcff;
-$error: #d50000;
+$black: #000 !default;
+$white: #fff !default;
+$base: $white !default;
+$grey: #e0e0e0 !default;
+$grey-background: #bababa !default;
+$charcoal:#303030 !default;
+$primary: lighten($black, 13%) !default;//rgba(0,0,0,.87);
+$secondary: lighten($black, 46%) !default;
+$disabled: lighten($black, 62%) !default;
+$accent: #30bcff !default;
+$error: #d50000 !default;
 
 // Skin
-$background: $base;
-$text-color: $primary;
+$background: $base !default;
+$text-color: $primary !default;
 
 // Buttons
-$btn-color: $accent;
-$btn-color-secondary: #01a0ec;
-$btn-color-outline-highlighted: #c0ebff;
-$btn-color-disabled: #a4a4a4;
-$btn-font-size: 18;
-$btn-radius: 0;
-$btn-padding-x: 10;
-$btn-padding-y: 10;
-$btn-margin-x:	16;
-$btn-margin-y:	8;
+$btn-color: $accent !default;
+$btn-color-secondary: #01a0ec !default;
+$btn-color-outline-highlighted: #c0ebff !default;
+$btn-color-disabled: #a4a4a4 !default;
+$btn-font-size: 18 !default;
+$btn-radius: 0 !default;
+$btn-padding-x: 10 !default;
+$btn-padding-y: 10 !default;
+$btn-margin-x:	16 !default;
+$btn-margin-y:	8 !default;
 
 
 // Options

--- a/app/scss/themes/core/_dark.scss
+++ b/app/scss/themes/core/_dark.scss
@@ -1,6 +1,6 @@
 // Core variables and mixins
-@import '../../variables';
 @import 'variables_dark';
+@import '../../variables';
 
 // Core CSS
 @import '../../index';

--- a/app/scss/themes/core/_light.scss
+++ b/app/scss/themes/core/_light.scss
@@ -1,6 +1,6 @@
 // Core variables and mixins
-@import '../../variables';
 @import 'variables_light';
+@import '../../variables';
 
 // Core CSS
 @import '../../index';

--- a/app/scss/themes/core/_variables_dark.scss
+++ b/app/scss/themes/core/_variables_dark.scss
@@ -1,6 +1,6 @@
 // Colors
-$background: #303030;
-$primary: #fff;
-$secondary: lighten(#fff, 30%);
-$disabled: lighten(#fff, 50%);
-$accent: #30bcff;
+$background: #303030 !default;
+$primary: #fff !default;
+$secondary: lighten(#fff, 30%) !default;
+$disabled: lighten(#fff, 50%) !default;
+$accent: #30bcff !default;

--- a/app/scss/themes/core/_variables_light.scss
+++ b/app/scss/themes/core/_variables_light.scss
@@ -1,6 +1,6 @@
 // Colors
-$background: #fff;
-$primary: lighten(#000, 13%);
-$secondary: lighten(#000, 46%);
-$disabled: lighten(#000, 62%);
-$accent: #30bcff;
+$background: #fff !default;
+$primary: lighten(#000, 13%) !default;
+$secondary: lighten(#000, 46%) !default;
+$disabled: lighten(#000, 62%) !default;
+$accent: #30bcff !default;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "nativescript-fonticon": "^1.1.0",
     "nativescript-telerik-ui": "^1.3.1",
     "nativescript-themes": "^1.1.0",
-    "tns-core-modules": "^2.2.1"
+    "tns-core-modules": "^2.2.1",
+    "bootstrap": "next"
   },
   "devDependencies": {
     "babel-traverse": "6.13.0",
@@ -30,7 +31,7 @@
     "babylon": "6.9.0",
     "glob": "^7.0.5",
     "lazy": "1.0.11",
-    "nativescript-dev-sass": "^0.2.0",
+    "nativescript-dev-sass": "^0.3.0",
     "nativescript-dev-typescript": "^0.3.2",
     "typescript": "^1.8.10"
   },


### PR DESCRIPTION
With this PR you should be able to customize the scss theme in the following ways:

## Customize Theme Variables
In your `app.scss` file you can set the theme variables (or import another partial) before importing the theme file. [Example](https://github.com/NativeScript/theme/blob/allow-customizations/app/customized.android.scss#L8-L9)

## Base Theme On Bootstrap(v4)
This is useful **code share with Web project scenario**.
You reuse some of the styling form bootstrap theme (along with the cusomizations you have made on it). To do that - in your `app.scss`:

1. _(Optional)_ Import you `_custom.scss` with customization of bootstrap variables. This will be the way to [customize the bootstrap theme](https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss#L3-L4).

1.  Import `varialbes.scss` from the bootstrap theme. If installed with `npm` you can do it [like that](https://github.com/NativeScript/theme/blob/allow-customizations/app/bootstrap-based.android.scss#L8-L9).

1. [Import `bootstrap-map` ](https://github.com/NativeScript/theme/blob/allow-customizations/app/bootstrap-based.android.scss#L10-L11)to do the variable mapping.

1. Import the theme as usual.

Resolves #58 
Related to #5