### PR TITLE
The "inherit" value is currently not supported

### DIFF
--- a/app/scss/_variables.scss
+++ b/app/scss/_variables.scss
@@ -49,6 +49,7 @@ $btn-margin-y:	8 !default;
 // Headings
 $headings-margin-bottom: 4 !default;
 $headings-font-weight: normal !default;
+$headings-color: $primary !default;
 
 // Options
 //

--- a/app/scss/_variables.scss
+++ b/app/scss/_variables.scss
@@ -49,7 +49,6 @@ $btn-margin-y:	8 !default;
 // Headings
 $headings-margin-bottom: 4 !default;
 $headings-font-weight: normal !default;
-$headings-color: inherit !default;
 
 // Options
 //


### PR DESCRIPTION
`inherit` CSS value is currently not supported in NativeScript. In the `3.0` release we will log and error about [inherit] value not being valid. Better just remove it for now.