### PR TITLE
Inherit value isn't accepted for color attribute

### DIFF
--- a/app/scss/_variables.scss
+++ b/app/scss/_variables.scss
@@ -49,7 +49,7 @@ $btn-margin-y:	8 !default;
 // Headings
 $headings-margin-bottom: 4 !default;
 $headings-font-weight: normal !default;
-$headings-color: inherit !default;
+$headings-color: $primary !default;
 
 // Options
 //


### PR DESCRIPTION
I have upgraded my nativescript-angular app to RC 3.0. When I change of view, the console print this error:

JS: Error: Failed to apply property [color] with value [inherit] to Label(28). Error: Invalid color: inherit