### PR TITLE
change bootstrap version to fix sass compile error

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   },
   "dependencies": {
-    "bootstrap": "next",
+    "bootstrap": "4.0.0-alpha.6",
     "nativescript-dom": "^1.0.9",
     "nativescript-fonticon": "^1.1.1",
     "nativescript-telerik-ui": "^1.6.2",


### PR DESCRIPTION
selected the bootstrap version that corresponded to the tns-core-modules version 2.5.0 (feb 2017). This worked with tns cli 3.4.0 and node 8.9.3 deploying to android Marshmallow API 23 and iOS 11.2 from macOS High Sierra and Win 10.