### PR TITLE
Fix switch thumb color when using scss.

### DIFF
--- a/app/scss/_switch.scss
+++ b/app/scss/_switch.scss
@@ -1,6 +1,7 @@
 .switch {
   &[checked=true] {
     background-color: $accent;
+    color: $accent;
   }
 
   &[checked=true][isEnabled=false] {


### PR DESCRIPTION
This PR fixes a bug where the switch thumb was not grabbing the `$accent` color.

The next gif shows the issue. There, I change between css and scss themes. The scss themes render the switch thumb always in blue. 

![2018-10-15 14 13 49](https://user-images.githubusercontent.com/2600867/46953098-beca7580-d084-11e8-9f28-971d6c745491.gif)

This PR fixes that!

Thanks!
