### PR TITLE
Fix unapplied border-radius property

### DIFF
--- a/src/scss/mixins/components/_button.scss
+++ b/src/scss/mixins/components/_button.scss
@@ -46,10 +46,6 @@
 
         #{if($compat, '&-rounded-sm', '&.-rounded-sm')} {
             border-radius: const(border-radius-sm);
-
-            .ns-ios & {
-                border-radius: const(border-radius-sm) * 2;
-            }
         }
 
         #{if($compat, '&-rounded-lg', '&.-rounded-lg')} {

--- a/src/scss/mixins/components/_button.scss
+++ b/src/scss/mixins/components/_button.scss
@@ -38,14 +38,17 @@
         #{if($compat, '&-rounded-sm', '&.-rounded-sm')},
         #{if($compat, '&-rounded-lg', '&.-rounded-lg')} {
             height: const(btn-height) - 12;
+
+            .ns-android & {
+                margin: const(btn-margin-y) const(btn-margin-x);
+            }
+        }
+
+        #{if($compat, '&-rounded-sm', '&.-rounded-sm')} {
             border-radius: const(border-radius-sm);
 
             .ns-ios & {
                 border-radius: const(border-radius-sm) * 2;
-            }
-
-            .ns-android & {
-                margin: const(btn-margin-y) const(btn-margin-x);
             }
         }
 

--- a/src/scss/variables/_index.scss
+++ b/src/scss/variables/_index.scss
@@ -35,7 +35,7 @@ $headings-font-weight: normal !default;
 $border-width: 1 !default;
 // Needs to be defined, to mitigate leftover radii from other themes
 $border-radius: null !default;
-$border-radius-sm: 2 !default;
+$border-radius-sm: 4 !default;
 $border-radius-lg: 50% !default;
 $border-radius-rounded: 5 !default;
 


### PR DESCRIPTION
The `border-radius` property of the CSS class `button.-rounded-lg` is not applied when `.ns-ios`