### PR TITLE
fix: add more padding to action items

### DIFF
--- a/src/scss/mixins/components/_action-bar.scss
+++ b/src/scss/mixins/components/_action-bar.scss
@@ -18,7 +18,7 @@
         #{$item-selectors} {
             android-elevation: 0;
             font-size: const(font-size);
-            padding: 12 3;
+            padding: 12 7;
             margin: 0;
             min-width: 0;
             width: auto;


### PR DESCRIPTION
This adds padding to the action items on Android, so that they are not cluttered to each other.