### PR TITLE
feat: add Frame control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Repository
+nativescript-theme-core/
+package-lock.json
+
 # NativeScript
 hooks/
 node_modules/

--- a/src/scss/core/_controls.scss
+++ b/src/scss/core/_controls.scss
@@ -10,6 +10,12 @@
                 '.nt-label')
     );
 
+
+    @include frame(
+                ('Frame',
+                '.nt-frame')
+    );
+
     @include page(
                 ('Page',
                 '.nt-page')

--- a/src/scss/mixins/components/_controls.scss
+++ b/src/scss/mixins/components/_controls.scss
@@ -8,6 +8,12 @@
     }
 }
 
+@mixin frame($selectors) {
+    #{$selectors} {
+        @include colorize($background-color: background);
+    }
+}
+
 @mixin page($selectors) {
     #{$selectors} {
         @include colorize(


### PR DESCRIPTION
Preconditions:
- Android platform
- `Frame` as an application root view

According to the preconditions, there is a white screen blink when launching the application.
It is due to no background color definition for the Frame, so it results in showing a white screen before executing the navigation to the default page.