### PR TITLE
fix: Bootstrap and .nt-form colors not adapting to skin

### DIFF
--- a/src/scss/_bootstrap.scss
+++ b/src/scss/_bootstrap.scss
@@ -1,0 +1,28 @@
+// Contextual colors and backgrounds http://v4-alpha.getbootstrap.com/components/utilities/#contextual-colors-and-backgrounds
+.text-primary {
+  @include colorize($color: accent);
+}
+
+.text-danger {
+  color: const(error);
+}
+
+.bg-primary {
+  @include colorize($color: accent);
+  color: $white;
+}
+
+.bg-danger {
+  background-color: const(error);
+  color: $white;
+}
+
+// Image shapes http://v4-alpha.getbootstrap.com/content/images/#image-shapes
+.img-rounded {
+  border-radius: const(border-radius-sm);
+}
+
+.img-circle {
+  border-radius: const(border-radius-lg);
+}
+

--- a/src/scss/_controls.scss
+++ b/src/scss/_controls.scss
@@ -56,6 +56,11 @@
 
     // Forms
 
+    @include form-skin(
+                ('Form',
+                '.nt-form')
+    );
+
     @include form-fields-skin();
 
     @include input-component-skin(

--- a/src/scss/_index.scss
+++ b/src/scss/_index.scss
@@ -1,5 +1,6 @@
 // Specifics
 @import './controls';
+@import './bootstrap';
 
 /* Dividers */
 

--- a/src/scss/core/primitives/_bootstrap.scss
+++ b/src/scss/core/primitives/_bootstrap.scss
@@ -1,15 +1,6 @@
 
 // # BOOTSTRAP #
 // ## Utilities ##
-// Image shapes http://v4-alpha.getbootstrap.com/content/images/#image-shapes
-.img-rounded {
-  border-radius: const(border-radius-sm);
-}
-
-.img-circle {
-  border-radius: const(border-radius-lg);
-}
-
 .img-thumbnail {
   border-radius: 0;
 }
@@ -34,23 +25,4 @@
 //Vertical centering
 .m-y-auto {
   vertical-align: center;
-}
-
-// Contextual colors and backgrounds http://v4-alpha.getbootstrap.com/components/utilities/#contextual-colors-and-backgrounds
-.text-primary {
-  color: light(accent);
-}
-
-.text-danger {
-  color: const(error);
-}
-
-.bg-primary {
-  background-color: light(accent);
-  color: $white;
-}
-
-.bg-danger {
-  background-color: const(error);
-  color: $white;
 }

--- a/src/scss/mixins/components/_forms.scss
+++ b/src/scss/mixins/components/_forms.scss
@@ -2,12 +2,7 @@
 
 @mixin form($selectors) {
     #{$selectors} {
-        font-family: 'Roboto Regular';
         padding: 16 0 10;
-
-        .ns-ios & {
-            font-family: 'SF UI Text Regular', system;
-        }
 
         .-center {
             horizontal-align: center;
@@ -17,21 +12,12 @@
             margin: 20 0;
         }
 
-        .nt-form__link {
-            @include colorize($color: accent);
-        }
-
-        .nt-form__title {
-            font-size: const(btn-font-size);
-        }
-
         .nt-form__logo {
             margin: 20 0;
             width: 50%;
         }
 
         .nt-form__validation-message {
-            color: const(error);
             margin: 1 0 0;
             padding: 0;
             height: 19;
@@ -45,11 +31,6 @@
                 width: 50%;
                 margin: 5;
             }
-        }
-
-        // Set isEnabled="false" on the whole form
-        &[isEnabled=false] * {
-            opacity: const(disabled-opacity);
         }
     }
 }
@@ -332,6 +313,26 @@
     }
 }
 
+@mixin form-skin($selectors) {
+    #{$selectors} {
+        .nt-form__title {
+            font-size: const(btn-font-size);
+        }
+
+        .nt-form__link {
+            @include colorize($color: accent);
+        }
+
+        .nt-form__validation-message {
+            color: const(error);
+        }
+
+        // Set isEnabled="false" on the whole form
+        &[isEnabled=false] * {
+            opacity: const(disabled-opacity);
+        }
+    }
+}
 
 @mixin form-fields-skin() {
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Currently .text-primary and .nt-form__link classes are not dependent on skin colors, while they should be.

## What is the new behavior?
.text-primary and .nt-form__link classes change colors with the current skin.

Fixes #245.