### PR TITLE
fix: RadCalendar (and probably other plugins) not following forced mode changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,19 @@ if (oldSystemAppearanceChanged) {
     };
 }
 
+// Make sure to substitute systemAppearance method too, as some plugins call it directly
+const oldSystemAppearance = app.systemAppearance;
+
+if (oldSystemAppearance) {
+    app.systemAppearance = function () {
+        if (Theme.currentMode === Theme.Auto) {
+            return oldSystemAppearance.call(this, ...arguments);
+        }
+
+        return Theme.currentMode.substr(3);
+    };
+}
+
 /* Deprecated root class setters, now available in core modules */
 function updateRootClasses(orientation, root = app.getRootView(), classes = []) {
     const classList = new ClassList(root.className);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Plugins aware of dark mode and using {N} way to get it are not following force mode changes.

## What is the new behavior?
Plugins are changing according to forced Theme mode.

Fixes #250.