### PR TITLE
fix: CSS variables output with node-sass is causing crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
-<a name="2.3.0"></a>
-## [2.3.0](https://github.com/NativeScript/theme/compare/v2.2.1...v2.3.0) (2020-01-13)
+<a name="2.3.2"></a>
+## [2.3.2](https://github.com/NativeScript/theme/compare/v2.2.1...v2.3.2) (2020-02-20)
+
+### Fixes
+
+* CSS variables output with **node-sass** is causing crashes
+
+<a name="2.3.1"></a>
+## [2.3.1](https://github.com/NativeScript/theme/compare/v2.2.1...v2.3.1) (2020-01-13)
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/theme",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Telerik NativeScript Core Theme",
   "author": "Telerik <support@telerik.com>",
   "homepage": "https://www.nativescript.org",
@@ -14,14 +14,14 @@
   "nativescript": {
     "id": "org.nativescript.theme",
     "tns-ios": {
-      "version": "6.3.0"
+      "version": "6.4.0"
     },
     "tns-android": {
-      "version": "6.3.1"
+      "version": "6.4.1"
     }
   },
   "dependencies": {
-    "@nativescript/core": "~6.3.2",
+    "@nativescript/core": "~6.4.1",
     "@nativescript/theme": "./src",
     "bootstrap": "4.3.1",
     "nativescript-picker": "~2.1.2",
@@ -31,7 +31,7 @@
     "nativescript-ui-sidedrawer": "~8.0.0",
     "nativescript-ui-dataform": "~6.0.0",
     "nativescript-ui-listview": "~8.0.1",
-    "tns-core-modules": "~6.3.2"
+    "tns-core-modules": "~6.4.1"
   },
   "devDependencies": {
     "@babel/core": "7.7.7",
@@ -44,9 +44,9 @@
     "lazy": "1.0.11",
     "nativescript-dev-webpack": "1.4.1",
     "resolve-url-loader": "3.1.0",
-    "sass": "1.24.3",
+    "sass": "1.25.0",
     "sass-lint": "1.13.1",
-    "sass-loader": "8.0.0",
+    "sass-loader": "8.0.2",
     "speed-measure-webpack-plugin": "1.3.1",
     "webpack": "4.40.2",
     "webpack-bundle-analyzer": "3.5.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/theme",
-  "version": "2.2.1",
+  "version": "2.3.2",
   "description": "Telerik NativeScript Core Theme",
   "author": "Telerik <support@telerik.com>",
   "main": "index",

--- a/src/scss/core/colors/_index.scss
+++ b/src/scss/core/colors/_index.scss
@@ -19,12 +19,12 @@ $border-color: $focus !default;
 
 $colors:  (
     // Core colors
-    black: $black,
-    white: $white,
+    "black": $black,
+    "white": $white,
     grey: $grey,
     grey-light: $grey-background,
     charcoal: $charcoal,
-    transparent: transparent,
+    "transparent": transparent,
 
     // Accents
     aqua: #00caab,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Using SASS with node-sass crashes the app due to broken compilation.

## What is the new behavior?
Compilation is fixes, app doesn't crash.

Fixes #234.

## Comments
Libsass treats map keys as colors if they don't have quotes.