### PR TITLE
fix: inputs don't provide styling for custom components.

### DIFF
--- a/app/pages/forms.xml
+++ b/app/pages/forms.xml
@@ -1,5 +1,6 @@
 <Page xmlns="http://schemas.nativescript.org/tns.xsd"
       xmlns:actionBar="/action-bar"
+      xmlns:mtf="nativescript-masked-text-field"
       navigatingTo="navigatingTo">
     <actionBar:action-bar actionBarTitle="Forms"/>
     <ScrollView>
@@ -23,6 +24,9 @@
             <TextField hint="TextField.-border Disabled" class="-border m-b-10" isEnabled="false"/>
             <TextField hint="TextField.-rounded-sm Disabled" class="-rounded-sm m-b-10" isEnabled="false"/>
             <TextField hint="TextField.-rounded-lg Disabled" class="-rounded-lg m-b-10" isEnabled="false"/>
+            <mtf:MaskedTextField hint=".nt-input.-border" class="nt-input -border m-b-10" text="" mask="(999) 999-9999" keyboardType="phone"/>
+            <mtf:MaskedTextField hint=".nt-input.-rounded-sm" class="nt-input -rounded-sm m-b-10" text="" mask="(999) 999-9999" keyboardType="phone"/>
+            <mtf:MaskedTextField hint=".nt-input.-rounded-lg" class="nt-input -rounded-lg m-b-10" text="" mask="(999) 999-9999" keyboardType="phone"/>
 
             <TextView hint="TextView"/>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/theme",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Telerik NativeScript Core Theme",
   "author": "Telerik <support@telerik.com>",
   "homepage": "https://www.nativescript.org",
@@ -14,24 +14,25 @@
   "nativescript": {
     "id": "org.nativescript.theme",
     "tns-ios": {
-      "version": "6.4.2"
+      "version": "6.5.0"
     },
     "tns-android": {
-      "version": "6.4.1"
+      "version": "6.5.0"
     }
   },
   "dependencies": {
-    "@nativescript/core": "~6.5.0",
+    "@nativescript/core": "~6.5.1",
     "@nativescript/theme": "./src",
     "bootstrap": "4.3.1",
     "nativescript-picker": "~2.1.2",
     "nativescript-datetimepicker": "~1.2.2",
     "nativescript-themes": "2.0.1",
     "nativescript-ui-autocomplete": "~6.0.1",
-    "nativescript-ui-sidedrawer": "~8.0.0",
+    "nativescript-ui-sidedrawer": "~8.0.1",
     "nativescript-ui-dataform": "~6.0.0",
-    "nativescript-ui-listview": "~8.0.1",
-    "tns-core-modules": "~6.5.0"
+    "nativescript-ui-listview": "~8.1.2",
+    "nativescript-masked-text-field": "~4.0.3",
+    "tns-core-modules": "~6.5.1"
   },
   "devDependencies": {
     "@babel/core": "7.7.7",

--- a/src/scss/_controls.scss
+++ b/src/scss/_controls.scss
@@ -61,18 +61,20 @@
                 '.nt-form')
     );
 
-    @include form-fields-skin();
+    @include form-fields-skin(
+                ('.nt-input')
+    );
 
     @include input-component-skin(
                 ('.nt-input')
     );
 
   @include action-bar-skin(
-              ('ActionBar',
-              '.nt-action-bar'),
-              ('Label',
-              'Button',
-              '.nt-action-bar__item')
+                ('ActionBar',
+                '.nt-action-bar'),
+                ('Label',
+                'Button',
+                '.nt-action-bar__item')
   );
 
 } @else {

--- a/src/scss/core/_controls.scss
+++ b/src/scss/core/_controls.scss
@@ -77,7 +77,9 @@
                 '.nt-form')
     );
 
-    @include form-fields();
+    @include form-fields(
+                ('.nt-input')
+    );
 
     @include input-component(
                 ('.nt-input')

--- a/src/scss/mixins/components/_forms.scss
+++ b/src/scss/mixins/components/_forms.scss
@@ -36,12 +36,13 @@
 }
 
 
-@mixin form-fields() {
+@mixin form-fields($selectors: '') {
 
     /* Form Validation styling */
 
     #{if($compat, '.input',
-        ('TextView',
+        ($selectors,
+         'TextView',
          'TextField',
          'PickerField',
          'DatePickerField',
@@ -60,7 +61,8 @@
     /* Form fields */
 
     #{if($compat, '.input',
-        ('TextView',
+        ($selectors,
+         'TextView',
          'TextField',
          'PickerField',
          'DatePickerField',
@@ -75,28 +77,28 @@
         font-size: const(font-size);
         padding: 8 0 4;
         margin: 5 16;
+    }
 
-        #{if($compat,
-            ('&.input-rounded',
-             '&.input-border'),
-            ('&.-rounded-sm',
-             '&.-rounded-lg',
-             '&.-border'))} {
-            border-width: const(border-width);
-            padding: 12 14;
-        }
+    #{if($compat,
+        ('.input-rounded',
+         '.input-border'),
+        ('.-rounded-sm',
+         '.-rounded-lg',
+         '.-border'))} {
+        border-width: const(border-width);
+        padding: 12 14;
+    }
 
-        #{if($compat, '&.input-border', '&.-rounded-sm')} {
-            border-radius: const(border-radius-sm);
-        }
+    #{if($compat, '.input-border', '.-rounded-sm')} {
+        border-radius: const(border-radius-sm);
+    }
 
-        #{if($compat, '&.input-rounded', '&.-rounded-lg')} {
-            border-radius: const(border-radius-lg);
-        }
+    #{if($compat, '.input-rounded', '.-rounded-lg')} {
+        border-radius: const(border-radius-lg);
+    }
 
-        &[isEnabled=false] {
-            opacity: const(disabled-opacity);
-        }
+    [isEnabled=false] {
+        opacity: const(disabled-opacity);
     }
 
     TextView[editable=false] {
@@ -248,6 +250,7 @@
     }
 
     @if $enable-rounded {
+        #{$selectors},
         TextView,
         TextField,
         PickerField,
@@ -275,28 +278,43 @@
 
 
 @mixin input-component($selectors) {
-    #{$selectors} {
-        margin: 10 0;
+    FlexboxLayout#{$selectors},
+    GridLayout#{$selectors},
+    StackLayout#{$selectors} {
+        border-width: 0;
+        border-radius: none;
+        padding: 0;
+    }
 
+    #{$selectors} {
         @at-root DataFormEditorLabel,
-        & #{if($compat, '.label', '> Label')} {
+        #{if($compat, '& .label', '& > .nt-label, & > Label')} {
             font-size: const(font-size);
             color: const(grey-light);
         }
 
         @at-root DataFormEditorLabel,
-        & #{if($compat, '.label', '> Label')},
-        & #{if($compat, '.input', '> TextView, > TextField, > PickerField, > DatePickerField, > TimePickerField, > DateTimePickerFields, > RadAutoCompleteTextView')} {
-            margin: 0 16;
+        #{if($compat,
+            ('& .label',
+             '& .input'),
+            ('& > .nt-label',
+             '& > .nt-input',
+             '& > Label',
+             '& > TextView',
+             '& > TextField',
+             '& > PickerField',
+             '& > DatePickerField',
+             '& > TimePickerField',
+             '& > DateTimePickerFields',
+             '& > RadAutoCompleteTextView'))} {
+            margin: 0;
         }
 
         #{if($compat, '&.input-sides', '&.-sides')} {
-            margin: 0 0 10;
+            margin-bottom: 10;
 
-            #{if($compat, '.label', '> Label')} {
-                margin: 5 16;
-
-                @if $enable-rounded {
+            @if $enable-rounded {
+                #{if($compat, '& > .label', '& > .nt-label, & > Label')} {
                     margin-top: 11;
                 }
             }
@@ -334,12 +352,13 @@
     }
 }
 
-@mixin form-fields-skin() {
+@mixin form-fields-skin($selectors: '') {
 
     /* Form fields */
 
     #{if($compat, '.input',
-        ('TextView',
+        ($selectors,
+         'TextView',
          'TextField',
          'PickerField',
          'DatePickerField',
@@ -469,7 +488,7 @@
 @mixin input-component-skin($selectors) {
     #{$selectors} {
         @at-root DataFormEditorLabel,
-        & #{if($compat, '.label', '> Label')} {
+        #{if($compat, '& .label', '& > .nt-label, & > Label')} {
             @include colorize($contrasted-color: accent background 30%);
         }
     }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
Custom components based on TextField can't be styled as a TextField easily.

## What is the new behavior?
.nt-input class to style them.

Fixes #261.

BREAKING CHANGES:

* `.nt-input` class is now used for both inputs and input groups. The group top/bottom margin is removed and the whole group has the same margin as the TextField. The overall look is the same. Low impact - users most likely don't rely on the group margin at all.
