### PR TITLE
fix(system-theme): Make sure setting Theme to Auto applies the changes

### DIFF
--- a/app/pages/themes.js
+++ b/app/pages/themes.js
@@ -1,10 +1,10 @@
 import { BaseModel } from "./base";
 import themes from "nativescript-themes";
 import * as application from "tns-core-modules/application";
-import { ClassList } from "@nativescript/theme";
+import { Theme } from "@nativescript/theme";
 
 const currentTheme = {
-    theme: "core.light",
+    theme: "core.auto",
     skin: "",
     css: ""
 };
@@ -45,14 +45,7 @@ export class ThemesModel extends BaseModel {
 
         const themeName = this.getThemeName(currentTheme.theme);
 
-        const rootView = application.getRootView();
-        const classList = new ClassList(rootView.className);
-
-        classList
-            .remove("ns-light", "ns-dark")
-            .add(`ns-${themeName.toLowerCase()}`);
-
-        rootView.className = classList.get();
+        Theme.setMode(Theme[themeName]);
 
         this.set("theme", `${themeName} ${this.getThemeName(currentTheme.skin)}`);
 
@@ -86,10 +79,11 @@ export class ThemesModel extends BaseModel {
 
     getThemeName(cssPath) {
         if (cssPath.indexOf("core.light") > -1) {
-
             return "Light";
         } else if (cssPath.indexOf("core.dark") > -1) {
             return "Dark";
+        } else if (cssPath.indexOf("core.auto") > -1) {
+            return "Auto";
         } else if (cssPath.indexOf("customized") > -1) {
             return "Custom";
         } else if (cssPath.indexOf("bootstrap-based") > -1) {

--- a/app/pages/themes.xml
+++ b/app/pages/themes.xml
@@ -2,14 +2,14 @@
   <ScrollView>
     <StackLayout>
       <Label text="{{ 'Active: ' + theme }}" textWrap="true" class="h3 text-center m-10" />
+
+      <FlexboxLayout flexDirection="row" flexWrap="wrap">
+        <Button text="Auto" tap="{{ applyTheme }}" class="-outline m-5" cssName="core.auto" />
+      </FlexboxLayout>
+
       <FlexboxLayout flexDirection="row" flexWrap="wrap">
         <Button text="Light" tap="{{ applyTheme }}" class="-outline m-5" cssName="core.light" />
         <Button text="Dark" tap="{{ applyTheme }}" class="-outline m-5" cssName="core.dark" />
-      </FlexboxLayout>
-
-      <Label class="hr-dark" />
-
-      <FlexboxLayout flexDirection="row" flexWrap="wrap">
         <Button text="Bootstrap" tap="{{ applyTheme }}" class="-outline m-5" cssName="bootstrap-based" />
         <Button text="Custom" tap="{{ applyTheme }}" class="-outline m-5" cssName="customized" />
       </FlexboxLayout>

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   "nativescript": {
     "id": "org.nativescript.theme",
     "tns-ios": {
-      "version": "6.5.0"
+      "version": "6.5.1"
     },
     "tns-android": {
-      "version": "6.5.0"
+      "version": "6.5.1"
     }
   },
   "dependencies": {
-    "@nativescript/core": "~6.5.1",
+    "@nativescript/core": "~6.5.2",
     "@nativescript/theme": "./src",
     "bootstrap": "4.3.1",
     "nativescript-picker": "~2.1.2",
@@ -32,7 +32,7 @@
     "nativescript-ui-dataform": "~6.0.0",
     "nativescript-ui-listview": "~8.1.2",
     "nativescript-masked-text-field": "~4.0.3",
-    "tns-core-modules": "~6.5.1"
+    "tns-core-modules": "~6.5.2"
   },
   "devDependencies": {
     "@babel/core": "7.7.7",

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import * as appCommon from "tns-core-modules/application/application-common";
 import * as app from "tns-core-modules/application";
-import { removeFromRootViewCssClasses } from "tns-core-modules/css/system-classes";
+import { removeFromRootViewCssClasses, removeCssClass } from "tns-core-modules/css/system-classes";
 import { device, isAndroid, screen } from "tns-core-modules/platform";
 import * as view from "tns-core-modules/ui/core/view";
 import * as frame from "tns-core-modules/ui/frame";
+
+const removeClass = removeCssClass || removeFromRootViewCssClasses;
 
 const display = screen.mainScreen;
 const whiteSpaceRegExp = /\s+/;
@@ -50,9 +52,12 @@ export class Theme {
         classList.remove(Theme.Light, Theme.Dark);
 
         if (Theme.currentMode !== Theme.Auto) {
-            removeFromRootViewCssClasses(Theme.Light);
-            removeFromRootViewCssClasses(Theme.Dark);
+            removeClass(Theme.Light);
+            removeClass(Theme.Dark);
             classList.add(Theme.currentMode);
+        } else {
+            // Reset to Auto system theme
+            setTimeout(appCommon.systemAppearanceChanged.bind(this, Theme.rootView, app.systemAppearance()));
         }
 
         Theme.rootView.className = classList.get();

--- a/src/scss/mixins/components/_forms.scss
+++ b/src/scss/mixins/components/_forms.scss
@@ -282,7 +282,7 @@
     GridLayout#{$selectors},
     StackLayout#{$selectors} {
         border-width: 0;
-        border-radius: none;
+        border-radius: 0;
         padding: 0;
     }
 


### PR DESCRIPTION
Fix a border-radius error in RDF

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
If the device is in dark mode, setting forced theme to light/dark and back to auto leaves the app in light mode.

## What is the new behavior?
The app is returned to the current device mode.

Fixes/Implements/Closes #265.
