### PR TITLE
Fix rem-to-dip

### DIFF
--- a/src/scss/mixins/_utilities.scss
+++ b/src/scss/mixins/_utilities.scss
@@ -44,7 +44,7 @@
 }
 
 @function rem-to-dip($size) {
-    @if unit($size) != 'em' or unit($size) != 'rem' {
+    @if unit($size) != 'em' and unit($size) != 'rem' {
         @return $size / ($size * 0 + 1);
     }
 


### PR DESCRIPTION
Started trying to use this mixin then noticed a logic error.

The unit of `$size` will always be `(!em || !rem)` because if it's one it's not the other. Changed to `and` because I think that's the desired functionality? It looks like the fallback case is to strip the units off of the input value, seems a little strange, might need further discussion about what's actually going on here?

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
  - Link is also a 404, please update this template.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
  - N/A. Feel free to open if it seems necessary.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
  - Link is also a 404, please update this template.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.
  - Link is also a 404, please update this template.

## What is the current behavior?
`rem-to-dip` always returns the input size without units, for example:
```scss
// $font-size: 12;
// Functon call
font-size: rem-to-dip(1.7rem);
// Desired output
font-size: 20;
// Actual Output
font-size: 1.7;
```

## What is the new behavior?
`rem-to-dip` will return `$size * $font-size` for `em` or `rem` units, and a fraction for other units. Not certain `em` should be included because the result is not accurate. Not fixed: `rem/em` is not stripped from rem/em units. so the actual output is `font-size: 20rem;` which is interpreted as DIPs.

BREAKING CHANGES:
N/A

Migration steps:
N/A

