### PR TITLE
Fixes Error "appCommon is not defined"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export class Theme {
             classList.add(Theme.currentMode);
         } else {
             // Reset to Auto system theme
-            setTimeout(appCommon.systemAppearanceChanged.bind(this, Theme.rootView, Application.systemAppearance()));
+            setTimeout(Application.systemAppearanceChanged.bind(this, Theme.rootView, Application.systemAppearance()));
         }
 
         Theme.rootView.className = classList.get();


### PR DESCRIPTION
Fixes #280 it looks like at some point this might have been changed from appCommon to Application and this reference missed.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages. (404)
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it. #280 
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests. (404)
- [x] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md. N/A?

## What is the current behavior?
#280 

## What is the new behavior?
Works as expected, calling `Theme.setMode(Theme.Auto)` resets to system's Dark Mode Setting.

Fixes #280.
