### PR TITLE
fix: NS6/7 setMode fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="2.3.4"></a>
+## [2.3.4](https://github.com/NativeScript/theme/compare/v2.3.3...v2.3.4) (2020-12-05)
+
+### Fixes
+
+* setMode should work correctly in all cases
+* Disables system theme so that NS themes can work properly...
+* Theme should work on NS 6 & 7 properly
+
+
 <a name="2.3.3"></a>
 ## [2.3.3](https://github.com/NativeScript/theme/compare/v2.3.2...v2.3.3) (2020-03-17)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/theme",
-  "version": "3.0.0",
+  "version": "2.3.4",
   "description": "NativeScript Core Theme",
   "author": "NativeScript <support@nativescript.org>",
   "homepage": "https://www.nativescript.org",
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@nativescript/core": "rc",
+    "@nativescript/core": "latest",
     "@nativescript/theme": "./src",
     "bootstrap": "~4.5.2",
     "nativescript-picker": "~2.1.2",
@@ -34,10 +34,7 @@
     "nativescript-masked-text-field": "~4.0.3"
   },
   "devDependencies": {
-    "@babel/core": "7.7.7",
-    "@babel/parser": "7.7.5",
-    "@babel/plugin-transform-modules-commonjs": "7.7.5",
-    "babel-eslint": "10.0.3",
+    "babel-eslint": "^10.0.3",
     "cache-loader": "4.1.0",
     "eslint": "6.4.0",
     "glob": "7.1.4",

--- a/scripts/builder.js
+++ b/scripts/builder.js
@@ -9,7 +9,6 @@ const fs = require("fs");
 const sass = require("sass");
 const glob = require("glob");
 const pjs = require("../package.json");
-const babel = require("@babel/core");
 const parse = require("@nativescript/core/css").parse;
 
 // Kill The original folder, so that way it is a clean folder
@@ -41,12 +40,6 @@ async function createThemeFiles() {
 
     createPackageJson();
 
-    // Transform imports to commonjs
-    // const transform = babel.transform(fs.readFileSync("./src/index.js"), {
-    //     plugins: ["@babel/transform-modules-commonjs"]
-    // });
-
-    // fs.writeFile("./nativescript-theme-core/index.js", transform.code, {}, () => { });
     copyFile("./src/index.js", "./nativescript-theme-core/index.js");
 
     // Copy typings

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/theme",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Telerik NativeScript Core Theme",
   "author": "Telerik <support@telerik.com>",
   "main": "index",


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
- setMode crashes do to some changes in the NS7 runtimes
- setMode doesn't change the theme properly

## What is the new behavior?
- setMode no longer crashes
- setMode changes the theme dynamically.

# Notes
This has already been published as 2.3.4 - To fix a Internal Support Issue.