### PR TITLE
fixes #293

### DIFF
--- a/src/scss/mixins/_utilities.scss
+++ b/src/scss/mixins/_utilities.scss
@@ -72,10 +72,10 @@
 }
 
 @function check-contrast($color) {
-    $color-brightness: round((red($color) * 299) + (green($color) * 587) + (blue($color) * 114) / 1000);
-    $light-color: round((red(#ffffff) * 299) + (green(#ffffff) * 587) + (blue(#ffffff) * 114) / 1000);
+    $color-brightness: round((red($color) * 299) + (green($color) * 587) + math.div(blue($color) * 114, 1000));
+    $light-color: round((red(#ffffff) * 299) + (green(#ffffff) * 587) + math.div(blue(#ffffff) * 114, 1000));
 
-    @return abs($color-brightness) < ($light-color / 1.7);
+    @return abs($color-brightness) < math.div($light-color, 1.7);
 }
 
 @function alternate($color, $lighten: 60%, $darken: null) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution!
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(blue($color) * 114, 1000)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
75 │     $color-brightness: round((red($color) * 299) + (green($color) * 587) + (blue($color) * 114) / 1000);
   │                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 75:76  check-contrast()
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 84:49  alternate()
    node_modules/@nativescript/theme/scss/variables/_index.scss 56:11   @import
    node_modules/@nativescript/theme/scss/core/_index.scss 2:9          @import
    node_modules/@nativescript/theme/core.scss 8:9                      @import
    app/_app-common.scss 1:9                                            root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(blue($color) * 114, 1000)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
75 │     $color-brightness: round((red($color) * 299) + (green($color) * 587) + (blue($color) * 114) / 1000);
   │                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 75:76  check-contrast()
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 84:49  alternate()
    node_modules/@nativescript/theme/scss/variables/_index.scss 56:11   @import
    node_modules/@nativescript/theme/scss/core/_index.scss 2:9          @import
    node_modules/@nativescript/theme/core.scss 8:9                      @import
    app/_app-common.scss 1:9                                            @import
    app/app.ios.scss 2:9                                                root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(blue($color) * 114, 1000)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
75 │     $color-brightness: round((red($color) * 299) + (green($color) * 587) + (blue($color) * 114) / 1000);
   │                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 75:76  check-contrast()
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 84:49  alternate()
    node_modules/@nativescript/theme/scss/variables/_index.scss 56:11   @import
    node_modules/@nativescript/theme/scss/core/_index.scss 2:9          @import
    node_modules/@nativescript/theme/core.scss 8:9                      @import
    app/_app-common.scss 1:9                                            @import
    app/app.android.scss 2:9                                            root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(blue(#ffffff) * 114, 1000)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
76 │     $light-color: round((red(#ffffff) * 299) + (green(#ffffff) * 587) + (blue(#ffffff) * 114) / 1000);
   │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 76:73  check-contrast()
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 84:49  alternate()
    node_modules/@nativescript/theme/scss/variables/_index.scss 56:11   @import
    node_modules/@nativescript/theme/scss/core/_index.scss 2:9          @import
    node_modules/@nativescript/theme/core.scss 8:9                      @import
    app/_app-common.scss 1:9                                            root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(blue(#ffffff) * 114, 1000)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
76 │     $light-color: round((red(#ffffff) * 299) + (green(#ffffff) * 587) + (blue(#ffffff) * 114) / 1000);
   │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 76:73  check-contrast()
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 84:49  alternate()
    node_modules/@nativescript/theme/scss/variables/_index.scss 56:11   @import
    node_modules/@nativescript/theme/scss/core/_index.scss 2:9          @import
    node_modules/@nativescript/theme/core.scss 8:9                      @import
    app/_app-common.scss 1:9                                            @import
    app/app.ios.scss 2:9                                                root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(blue(#ffffff) * 114, 1000)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
76 │     $light-color: round((red(#ffffff) * 299) + (green(#ffffff) * 587) + (blue(#ffffff) * 114) / 1000);
   │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 76:73  check-contrast()
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 84:49  alternate()
    node_modules/@nativescript/theme/scss/variables/_index.scss 56:11   @import
    node_modules/@nativescript/theme/scss/core/_index.scss 2:9          @import
    node_modules/@nativescript/theme/core.scss 8:9                      @import
    app/_app-common.scss 1:9                                            @import
    app/app.android.scss 2:9                                            root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($light-color, 1.7)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
78 │     @return abs($color-brightness) < ($light-color / 1.7);
   │                                       ^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 78:39  check-contrast()
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 84:49  alternate()
    node_modules/@nativescript/theme/scss/variables/_index.scss 56:11   @import
    node_modules/@nativescript/theme/scss/core/_index.scss 2:9          @import
    node_modules/@nativescript/theme/core.scss 8:9                      @import
    app/_app-common.scss 1:9                                            root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($light-color, 1.7)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
78 │     @return abs($color-brightness) < ($light-color / 1.7);
   │                                       ^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 78:39  check-contrast()
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 84:49  alternate()
    node_modules/@nativescript/theme/scss/variables/_index.scss 56:11   @import
    node_modules/@nativescript/theme/scss/core/_index.scss 2:9          @import
    node_modules/@nativescript/theme/core.scss 8:9                      @import
    app/_app-common.scss 1:9                                            @import
    app/app.ios.scss 2:9                                                root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($light-color, 1.7)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
78 │     @return abs($color-brightness) < ($light-color / 1.7);
   │                                       ^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 78:39  check-contrast()
    node_modules/@nativescript/theme/scss/mixins/_utilities.scss 84:49  alternate()
    node_modules/@nativescript/theme/scss/variables/_index.scss 56:11   @import
    node_modules/@nativescript/theme/scss/core/_index.scss 2:9          @import
    node_modules/@nativescript/theme/core.scss 8:9                      @import
    app/_app-common.scss 1:9                                            @import
    app/app.android.scss 2:9                                            root stylesheet
```

## What is the new behavior?
<!-- Describe the changes. -->
This will remove the warnings

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
#293 


